### PR TITLE
include stdint.h

### DIFF
--- a/src/internal.h
+++ b/src/internal.h
@@ -33,6 +33,7 @@
 
 #include <string.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include "moonfltk.h"
 #include <FL/Fl.H>
 #include "udata.h"


### PR DESCRIPTION
Hi, 

#include <stdint.h> was needed for building under Debian and Manjaro.

Without this include the following compile error occurred:

`browser.cc:148:5: error: ‘intptr_t’ was not declared in this scope`

Best regards,
Oliver