### PR TITLE
thread message queue

### DIFF
--- a/examples/other/multi-threading.lua
+++ b/examples/other/multi-threading.lua
@@ -16,24 +16,24 @@ local TRACE        = DEBUG and print or function() end
 
 local linda1 = lanes.linda()
 
-function background_code(threadName, initialSleepSeconds)
+local function background_code(threadName, initialSleepSeconds)
     -- This function together with simple upvalues is serialized and 
     -- transfered to another thread, see the LuaLanes documentation 
     -- for more details: http://lualanes.github.io/lanes/
-    TRACE(threadName.." started")
+    TRACE(threadName..": started.")
     local lanes = require"lanes"    -- module cannot be serialized
     local fl    = require"moonfltk" -- module cannot be serialized
     lanes.sleep(initialSleepSeconds)
-    for i= START_NUMBER, 0, -1 do
+    for i = START_NUMBER, 0, -1 do
         linda1:send(threadName, i)
         fl.awake("awake from " .. threadName)
         if i > 0 then
             lanes.sleep(1)
         end
     end
-    TRACE(threadName.." sending quit")
+    TRACE(threadName..": sending quit")
     linda1:send("quit", threadName)
-    fl.awake("awake from " .. threadName)
+    fl.awake("awake from " .. threadName.." for quit")
 end
 
 local createThread = lanes.gen("*", background_code)
@@ -55,26 +55,43 @@ local m1 = ""
 local m2 = ""
 local finished = {}
 
+TRACE("main: starting event loop.")
 while fl.wait() do
-    local m = fl.thread_message()
-    if m then
-        TRACE("thread_message: " , m)
+    TRACE("main: ------------- event loop activated -------------")
+
+    -- Read all thread messages.
+    -- If fl.awake was called with an optional message string,
+    -- tl.thread_message must be called to remove message
+    -- strings from queue. This is not necessary, if
+    -- fl.awake is called without argument.
+    -- In this example the thread message is only used
+    -- for demonstration.
+    repeat
+        local m = fl.thread_message()
+        if m then
+            TRACE("main: thread_message: " , m)
+        end
+    until m == nil
+
+    -- Read all linda events.
+    repeat    
         local k, v = linda1:receive(0, "thread1", "thread2", "quit")
-        TRACE("received from linda:", k, v)
-        if k == "thread1" then
-            m1 = v
-        elseif k == "thread2" then
-            m2 = v
-        elseif k == "quit" then
-            finished[v] = true
+        if k then
+            TRACE("main: received from linda:", k, v)
+            if k == "thread1" then
+                m1 = v
+            elseif k == "thread2" then
+                m2 = v
+            elseif k == "quit" then
+                finished[v] = true
+            end
+            local label = "Hello, World!\n - Received from thread1: " .. m1 .. ","
+                                    .. "\n - Received from thread2: " .. m2 .. "."
+            if finished.thread1 and finished.thread2 then
+                label = label .. "\nAll threads are finished!"
+            end
+            box:label(label)
         end
-        local label = "Hello, World!\n - Received from thread1: " .. m1 .. ","
-                                .. "\n - Received from thread2: " .. m2 .. "."
-        if finished.thread1 and finished.thread2 then
-            label = label .. "\nAll threads are finished!"
-        end
-        box:label(label)
-    else
-        TRACE("something happend in FLTK")
-    end
+    until k == nil
 end
+TRACE("main: event loop finished.")


### PR DESCRIPTION
The FLTK documentation says (and I verified that in the FLTK source code): 

> The default message handler saves the last message which can be accessed using the Fl::thread_message() function.

With the current implementation for `fl.awake` we can get the problem, that dropped message pointers will not be freed on the main thread thus leading to a memory leak.

To solve this, I implemented a FLTK message handler, that handles a message queue. FLTK itself manages a queue of these message handlers. 

The usage of the the message queue is optional, because `fl.awake` can be invoked without message string.

- `fl.awake` without argument will invoke [void Fl::awake()](http://www.fltk.org/doc-1.3/group__fl__multithread.html#gae9e8f440ce2ca05b047c620f75af13cb)
- `fl.awake` with message string argument will invoke [int Fl::awake(Fl_Awake_Handler cb, void *message)](http://www.fltk.org/doc-1.3/group__fl__multithread.html#ga22a404bcaf6641369e0725627d881556) with our new message handler that will handle the message queue.

