### PR TITLE
fl.lock() returns now boolean instead of integer

### DIFF
--- a/examples/other/multi-threading.lua
+++ b/examples/other/multi-threading.lua
@@ -7,8 +7,10 @@
 local lanes = require"lanes".configure()
 local fl    = require"moonfltk"
 
-fl.lock() -- "start" the FLTK lock mechanism
-          -- this is needed for initializing fl.await and fl.thread_message
+if not fl.lock()  -- "start" the FLTK lock mechanism
+then              -- this is needed for initializing fl.await and fl.thread_message
+    error("Multi threading not available in FLTK.")
+end
 
 local START_NUMBER = 15
 local DEBUG        = false

--- a/src/fl.cc
+++ b/src/fl.cc
@@ -58,10 +58,10 @@ static int Wait(lua_State *L)
     return 1;
     }
 
-
+// returns true if multithreading is available
 static int Lock(lua_State *L)
     {
-    lua_pushinteger(L, Fl::lock());
+    lua_pushboolean(L, Fl::lock() == 0);
     return 1;
     }
 


### PR DESCRIPTION
One minor thing: returning true instead of 0 for `fl.lock() == OK` feels more naturally.