### PR TITLE
bugfix memory corruption: corrected iteration for freeing all children,

### DIFF
--- a/src/browser.cc
+++ b/src/browser.cc
@@ -31,18 +31,15 @@ void browserclear(lua_State *L, Fl_Browser_ *p)
     int n = p->children();
     if(n<=0) 
         return;
-    Fl_Widget * const *arr = p->array();
-    if(!arr) 
-        return;
-    for(int i=0; i < n; i++)
+    for(int i=n-1; i >= 0; --i)
         {
-        Fl_Widget *c = arr[i];
+        Fl_Widget *c = p->child(i);
         /* skip scrollbars */
         if((c == &p->scrollbar) || (c == &p->hscrollbar))
             continue;
         if(userdata(c))
             {
-            p->remove(*c);
+            p->remove(i);
             userdata_unref(L, c);
             }
         }

--- a/src/group.cc
+++ b/src/group.cc
@@ -31,15 +31,12 @@ void groupclear(lua_State *L, Fl_Group *p)
     int n = p->children();
     if(n<=0) 
         return;
-    Fl_Widget * const *arr = p->array();
-    if(!arr)    
-        return;
-    for(int i=0; i < n; i++)
+    for(int i=n-1; i >= 0; --i)
         {
-        Fl_Widget *c = arr[i];
+        Fl_Widget *c = p->child(i);
         if(userdata(c))
             {
-            p->remove(*c);
+            p->remove(i);
             userdata_unref(L, c);
             }
         }
@@ -51,18 +48,15 @@ static void scrollclear(lua_State *L, Fl_Scroll *p)
     int n = p->children();
     if(n<=0) 
         return;
-    Fl_Widget * const *arr = p->array();
-    if(!arr)    
-        return;
-    for(int i=0; i < n; i++)
+    for(int i=n-1; i >= 0; --i)
         {
-        Fl_Widget *c = arr[i];
+        Fl_Widget *c = p->child(i);
         /* skip scrollbars */
         if((c == &p->scrollbar) || (c == &p->hscrollbar))
             continue;
         if(userdata(c))
             {
-            p->remove(*c);
+            p->remove(i);
             userdata_unref(L, c);
             }
         }

--- a/src/table.cc
+++ b/src/table.cc
@@ -45,17 +45,14 @@ void tableclear(lua_State *L, Fl_Table *p)
         return;
     p->rows(0);
     p->cols(0);
-    Fl_Widget * const *arr = p->array();
-    if(!arr)
-        return;
-    for(int i=0; i < n; i++)
+    for(int i=n-1; i >= 0; --i)
         {
-        Fl_Widget *c = arr[i];
+        Fl_Widget *c = p->child(i);
 //      if((c == Vscrollbar(p)) || (c == Hscrollbar(p))) continue;
         if(userdata(c))
             {
     //      printf("removing child %d\n", i);
-            p->remove(*c);
+            ((Fl_Group*)p)->remove(i);
             userdata_unref(L, c);
             }
         }

--- a/src/tree.cc
+++ b/src/tree.cc
@@ -31,18 +31,15 @@ void treeclear(lua_State *L, Fl_Tree *p)
     int n = p->children();
     if(n<=0) 
         return;
-    Fl_Widget * const *arr = p->array();
-    if(!arr) 
-        return;
-    for(int i=0; i < n; i++)
+    for(int i=n-1; i >= 0; --i)
         {
-        Fl_Widget *c = arr[i];
+        Fl_Widget *c = p->child(i);
         /* skip scrollbars */
         if(p->is_scrollbar(c))
             continue;
         if(userdata(c))
             {
-            ((Fl_Group*)p)->remove(*c);
+            ((Fl_Group*)p)->remove(i);
             userdata_unref(L, c);
             }
         }


### PR DESCRIPTION
Hi Stefano,

here comes a fix for problem: `Fl_Group::remove(i)` moves children i+1 to  i and invalidates the `Fl_Group::array()` pointer when going from 2 to 1 child, see the fltk implementation:

```
void Fl_Group::remove(int index) {
  ...
  children_--;
  if (children_ == 1) { // go from 2 to 1 child
    Fl_Widget *t = array_[!index];
    free((void*)array_);
    array_ = (Fl_Widget**)t;
  } else if (children_ > 1) { // delete from array
    for (; index < children_; index++) array_[index] = array_[index+1];
  }
  ...
}
```

Best regards,
Oliver