### PR TITLE
Allow passing an index to the value function for menu.cc.

### DIFF
--- a/src/menu.cc
+++ b/src/menu.cc
@@ -45,10 +45,14 @@ static int CheckIndex(lua_State *L, Fl_Menu_ *menu, int arg)
 /* Given the menu and the pathname at arg, returns the item's index or raises an error */
     {
 //  const char *pathname = luaL_optstring(L, arg, NULL); 
-    const char *pathname = lua_isnoneornil(L, arg) ? NULL : luaL_checkstring(L, arg);
-    if(pathname) 
-        return menu->find_index(pathname);
-    return luaL_argerror(L, arg, "cannot find item");
+    if (lua_isinteger(L, arg))
+        return lua_tointeger(L, arg);
+    else {
+        const char *pathname = lua_isnoneornil(L, arg) ? NULL : luaL_checkstring(L, arg);
+        if(pathname) 
+            return menu->find_index(pathname);
+        return luaL_argerror(L, arg, "cannot find item");
+    }
     }
 
 static const char *PushIndex(lua_State *L, Fl_Menu_ *menu, int index)


### PR DESCRIPTION
For menus and choices the value function works different than in C++ code. Instead of passing an index you need to pass the value to it. For most use cases this is better however sometimes I need to use the value function like I can in C++.

The way this patch works is if you pass an integer to the value function it will use that index without searching otherwise it will search for the value just as the code does before this patch.