### PR TITLE
Menu callback fix

### DIFF
--- a/src/menu.cc
+++ b/src/menu.cc
@@ -182,12 +182,14 @@ static int Menu_add(lua_State *L)
      * function has no mechanism to signal errors... */
     int shortcut = luaL_optinteger(L, 3, 0);
 
+    bool setCallback = false;
     int cbref = LUA_NOREF;
     if(!lua_isnoneornil(L, 4))
         {
         if(!lua_isfunction(L,4))
             return luaL_argerror(L, 4, "function or nil expected");
         reference(L, cbref, 4);
+        setCallback = true;
         }
 
     int argref = LUA_NOREF;
@@ -203,7 +205,7 @@ static int Menu_add(lua_State *L)
     ud->cbref = cbref;
     ud->argref = argref;
     
-    int index = menu->add(pathname, shortcut, CommonCallback, ud, flags);
+    int index = menu->add(pathname, shortcut, setCallback ? CommonCallback : nullptr, setCallback ? ud : nullptr, flags);
     if(moonfltk_trace_objects) 
         printf("added Menu_Item '%s' (index=%d) %p\n", pathname, index, (void*)ud);
     if(index==0) menu->value(0);

--- a/src/menu.cc
+++ b/src/menu.cc
@@ -364,8 +364,6 @@ static int Menu_mode(lua_State *L)
 static const struct luaL_Reg Menu_Methods[] = 
     {
         { "add",  Menu_add},
-//      { "callback", Menu_callback }, @@TODO: override widget:callback
-//      { "do_callback", Menu_do_callback }, @@TODO: override widget:do_callback
         { "clear", Menu_clear },
         { "clear_submenu", Menu_clear_submenu },
         { "down_box", Menu_down_box },


### PR DESCRIPTION
A callback is always specified for each menu item even if that is not what you want. With this patch if a callback is specified using add function everything will still function the same. If you don't specify a callback using add with this patch you can now use the widget callback.