### PR TITLE
Fix the image data function.

### DIFF
--- a/src/image.cc
+++ b/src/image.cc
@@ -182,9 +182,7 @@ static int Imagedata(lua_State *L) //@@DOC
         return 0;
     else if (count == 1) /* bitmap or color image */
         {
-        lua_pushstring(L, data[0]); /*@@ non va bene, è una binary string
-                                      lua_pushlstring(L, data[0], len);
-                                       ma dove prendere la len ?!? */
+        lua_pushlstring(L, data[0], p->w() * p->h() * p->d());
         return 1;
         } 
     else if (count > 2) // pixmap


### PR DESCRIPTION
This pull request resolves an issue where the string returned by the data function is the wrong size. This is because either the image contains a pixel with zero and in that case the string will be too short or lua_pushstring will access memory beyond the image data until it finds what it thinks is a null terminator. In that case the data function will return too much data.